### PR TITLE
Removes unnecessary count

### DIFF
--- a/security.tf
+++ b/security.tf
@@ -17,7 +17,6 @@ resource "aws_key_pair" "auth" {
 }
 
 resource "tls_private_key" "gen_key" {
-  count     = "1"
   algorithm = "RSA"
   rsa_bits  = "4096"
 }


### PR DESCRIPTION
Terraform 0.12 does not like the optional nature of the resources that depend on _this_ resource, so since this count is not needed, just removing it.