### PR TITLE
Removes centos6 as a supported platform

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -134,12 +134,6 @@ locals {
   }
 
   build_info = {
-    centos6 = {
-      ami_regex  = "spel-minimal-centos-6-hvm-\\d{4}\\.\\d{2}\\.\\d{1}\\.x86_64-gp2"
-      ami_search = "spel-minimal-centos-6-hvm-*.x86_64-gp2"
-      platform   = local.platform_info.lx
-    }
-
     centos7 = {
       ami_regex  = "spel-minimal-centos-7-hvm-\\d{4}\\.\\d{2}\\.\\d{1}\\.x86_64-gp2"
       ami_search = "spel-minimal-centos-7-hvm-*.x86_64-gp2"

--- a/variables.tf
+++ b/variables.tf
@@ -9,12 +9,12 @@ variable "subnet_id" {
 }
 
 variable "source_builds" {
-  default = ["win12", "win16", "win19", "rhel6", "rhel7", "centos6", "centos7"]
+  default = ["win12", "win16", "win19", "rhel6", "rhel7", "centos7"]
   type    = list(string)
 }
 
 variable "standalone_builds" {
-  default = ["win12", "win16", "win19", "rhel6", "rhel7", "centos6", "centos7"]
+  default = ["win12", "win16", "win19", "rhel6", "rhel7", "centos7"]
   type    = list(string)
 }
 


### PR DESCRIPTION
Centos6 has been fully deprecated, and there are no longer repos
hosting its packages. See:

* http://mirror.centos.org/centos/6/readme