### PR TITLE
Add sync to update submodule references

### DIFF
--- a/templates/lx_userdata.sh
+++ b/templates/lx_userdata.sh
@@ -247,6 +247,7 @@ install-watchmaker() {
   fi
 
   # Update submodule refs
+  try_cmd 1 git submodule sync
   try_cmd 1 git submodule update --init --recursive
 
   # Install watchmaker


### PR DESCRIPTION
This fixes an issue where updates to `.gitmodules` with the addition of a `branch` submodule key wasn't being processed.  Adding the `sync` updates the references and allows the submodule update to progress without issues.