### PR TITLE
Patches conflicting ucf and dpkg non-interactive update settings

### DIFF
--- a/templates/lx_userdata.sh
+++ b/templates/lx_userdata.sh
@@ -331,7 +331,7 @@ fi
 
 try_cmd 1 echo "ARRAY <ignore> devices=/dev/sda" >> /etc/mdadm/mdadm.conf
 
-export UCF_FORCE_CONFFNEW=1
+export DEBIAN_FRONTEND=noninteractive
 try_cmd 1 apt-get -y \
   -o Dpkg::Options::="--force-confdef" \
   -o Dpkg::Options::="--force-confnew" \


### PR DESCRIPTION
This update fixes the following error with updating the `grub-pc` package in Ubuntu 20.04:

```
Setting up grub-pc (2.04-1ubuntu26.11) ...
Error: Only one of force_conffold and force_conffnew should
       be set
dpkg: error processing package grub-pc (--configure):
 installed grub-pc package post-installation script subprocess returned error exit status 1
```