### PR TITLE
Ensures scap results are published for el8 builds

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -194,6 +194,7 @@ locals {
       aws_region            = local.aws_region
       build_slug            = local.build_slug
       build_type_builder    = local.build_type_builder
+      build_type_source     = local.build_type_source
       build_type_standalone = local.build_type_standalone
       debug                 = local.debug
       docker_slug           = local.docker_slug

--- a/templates/lx_test.sh
+++ b/templates/lx_test.sh
@@ -49,7 +49,7 @@ echo "***************************************************************"
 # everything below this is the TRY
 if [ -f "/etc/redhat-release" ]; then
   # this will only work for redhat and centos
-  cat /etc/redhat-release
+  cat /etc/os-release
 else
   lsb_release -a
 fi

--- a/templates/lx_userdata.sh
+++ b/templates/lx_userdata.sh
@@ -7,6 +7,7 @@ export LANG=en_US.UTF-8
 build_os="${build_os}"
 build_type="${build_type}"
 build_label="${build_label}"
+build_type_source="${build_type_source}"
 build_type_standalone="${build_type_standalone}"
 
 # shellcheck disable=SC2154
@@ -202,7 +203,7 @@ finally() {
   open-ssh
   publish-artifacts
   # shellcheck disable=SC2154
-  if [ "$build_type" == "$build_type_standalone" ] && [ "${scan_slug}" != "" ]; then
+  if [ "$build_type" == "$build_type_source" ] && [ "${scan_slug}" != "" ]; then
     publish-scap-scan
   fi
 

--- a/templates/lx_userdata.sh
+++ b/templates/lx_userdata.sh
@@ -200,6 +200,11 @@ finally() {
   # shellcheck disable=SC2154
   printf "%s\n" "$${userdata_status[@]}" > "${userdata_status_file}"
 
+  # disable fapolicyd so it can't block aws-cli
+  if systemctl is-active --quiet fapolicyd; then
+    systemctl stop fapolicyd
+  fi
+
   open-ssh
   publish-artifacts
   # shellcheck disable=SC2154

--- a/templates/lx_userdata.sh
+++ b/templates/lx_userdata.sh
@@ -167,14 +167,14 @@ publish-artifacts() {
   # move logs to s3
   artifact_dest="s3://$build_slug/$build_label"
   cp "${userdata_log}" "$artifact_dir"
-  aws s3 cp "$artifact_dir" "$artifact_dest" --recursive || true
+  aws s3 cp "$artifact_dir" "$artifact_dest" --recursive
   write-tfi "Uploaded logs to $artifact_dest" --result $?
 
   # creates compressed archive to upload to s3
   zip_file="$artifact_base/$${build_slug//\//-}-$build_label.tgz"
   cd "$artifact_dir"
   tar -cvzf "$zip_file" .
-  aws s3 cp "$zip_file" "s3://$build_slug/" || true
+  aws s3 cp "$zip_file" "s3://$build_slug/"
   write-tfi "Uploaded artifact zip to S3" --result $?
 }
 
@@ -187,7 +187,7 @@ publish-scap-scan() {
   # move scan output to s3
   # shellcheck disable=SC2154
   scan_dest="${scan_slug}/$build_os"
-  aws s3 cp "$scan_dir" "$scan_dest" --recursive || true
+  aws s3 cp "$scan_dir" "$scan_dest" --recursive
   write-tfi "Uploaded scap scan to $scan_dest" --result $?
 }
 

--- a/templates/win_userdata.ps1
+++ b/templates/win_userdata.ps1
@@ -3,6 +3,7 @@ $BuildOS = "${build_os}"
 $BuildType = "${build_type}"
 $BuildLabel = "${build_label}"
 $BuildTypeStandalone = "${build_type_standalone}"
+$BuildTypeSource = "${build_type_source}"
 
 # global vars
 $BuildSlug = "${build_slug}"
@@ -481,6 +482,6 @@ Write-UserdataStatus -UserdataStatus $UserdataStatus
 Open-Firewall
 Publish-Artifacts
 
-if (($BuildType -eq $BuildTypeStandalone) -and ("${scan_slug}" -ne "")) {
+if (($BuildType -eq $BuildTypeSource) -and ("${scan_slug}" -ne "")) {
   Publish-SCAP-Scan
 }


### PR DESCRIPTION
This pr is doing three things:

* Uses the source build instead of the standalone build to publish scap reports, because we currently the standalone el8 build will not actually run when FIPS is enabled
* There is a continuing issue with fapolicyd blocking `aws` after running watchmaker... For now at least, we can just disable fapolicyd to get past that
* Allows build to fail when it cannot push artifacts, so we catch this issue earlier if it ever happens again

