### PR TITLE
Forces submodule update to overwrite local changes (there can't be any anyway)

### DIFF
--- a/templates/lx_userdata.sh
+++ b/templates/lx_userdata.sh
@@ -273,7 +273,7 @@ install-watchmaker() {
 
   # Update submodule refs
   try_cmd 1 git submodule sync
-  try_cmd 1 git submodule update --init --recursive
+  try_cmd 1 git submodule update --init --recursive --force
 
   # Install watchmaker
   try_cmd 1 python3 -m pip install --upgrade --index-url "$PYPI_URL" --editable .


### PR DESCRIPTION
Fixes errors of this form, due to various updates to salt formulas, and cross-platform differences between windows and linux:

```
2023-09-26_16:11:36: git submodule update --init --recursive :: code 1 :: output: Submodule path 'src/watchmaker/static/salt/content': checked out '6f1911b0574bfb72a8cbb10c7d747f330d204633'
Submodule path 'src/watchmaker/static/salt/formulas/ash-linux-formula': checked out '15d5c902b60f25f971810b16e5ccbac78a823d25'
Submodule path 'src/watchmaker/static/salt/formulas/ntp-client-windows-formula': checked out '9a3eb30c7ce597ca385230db62f4cb594e647ab1'
error: Your local changes to the following files would be overwritten by checkout:
appveyor.yml
Please, commit your changes or stash them before you can switch branches.
Aborting
Submodule path 'src/watchmaker/static/salt/formulas/windows-update-agent-formula': checked out 'bcf98e2e306ba642f732b7f17dfc921c1587cd53'
Unable to checkout '8fee591ef5a2c6ed2763cca369f538db2aa29b68' in submodule path 'src/watchmaker/static/salt/formulas/pshelp-formula' : Failed
2023-09-26_16:11:38: Attempt 1, command failed :: git submodule update --init --recursive 
```